### PR TITLE
Tolerate missing variables

### DIFF
--- a/src/storeUtils.ts
+++ b/src/storeUtils.ts
@@ -60,10 +60,7 @@ function valueToObjectRepresentation(argObj: any, name: NameNode, value: ValueNo
     value.fields.map((obj) => valueToObjectRepresentation(nestedArgObj, obj.name, obj.value, variables));
     argObj[name.value] = nestedArgObj;
   } else if (isVariable(value)) {
-    if (! variables || !(value.name.value in variables)) {
-      throw new Error(`The inline argument "${value.name.value}" is expected as a variable but was not provided.`);
-    }
-    const variableValue = variables[value.name.value];
+    const variableValue = (variables || {})[value.name.value];
     argObj[name.value] = variableValue;
   } else if (isList(value)) {
     argObj[name.value] = value.values.map((listValue) => {

--- a/test/anywhere.ts
+++ b/test/anywhere.ts
@@ -217,6 +217,39 @@ describe('graphql anywhere', () => {
     });
   });
 
+  it('will tolerate missing variables', () => {
+    const resolver = (fieldName, _, args) => args;
+
+    const query = gql`
+      {
+        variables(int: $int, float: $float, string: $string, missing: $missing)
+      }
+    `;
+
+    const variables = {
+      int: 6,
+      float: 6.28,
+      string: 'varString',
+    };
+
+    const result = graphql(
+      resolver,
+      query,
+      null,
+      null,
+      variables,
+    );
+
+    assert.deepEqual(result, {
+      variables: {
+        int: 6,
+        float: 6.28,
+        string: 'varString',
+        missing: undefined,
+      },
+    });
+  });
+
   it('can use skip and include', () => {
     const resolver = (fieldName) => fieldName;
 


### PR DESCRIPTION
Allows `apollo-client` to pass the failing tests in https://github.com/apollostack/apollo-client/pull/1165 by tolerating missing variables when reading from the store. This is the part 2 of https://github.com/apollostack/apollo-client/pull/1174.

cc @helfer